### PR TITLE
Long .dot strings are now supported

### DIFF
--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -45,19 +45,26 @@ function _parse(file, callback, errback) {
 
   graphviz.stdout.on('data', function(data) {
     out += data;
-    eval(data.toString());
   });
   graphviz.stderr.on('data', function(data) {
     err += data;
   });
   graphviz.stdin.end();
   graphviz.on('exit', function(code) {
-    if(code !== 0 || __graph_eval === undefined) {
+    if(code !== 0) {
       if(errback) {
         errback(code, out, err);
       }
     } else {
-      callback(__graph_eval);
+      eval(out.toString());
+      if (typeof __graph_eval == "undefined") {
+        if(errback) {
+          errback(code, out, "__graph_eval is not defined in call to graphviz")
+        }
+      }
+      else {
+        callback(__graph_eval);
+      }
     }
   });
 }


### PR DESCRIPTION
Long .dot strings were causing multiple internal callbacks to the 'stdout' hander for the multiprocess communication, but the code assumed all output would occur in a single call to the 'stdout' handler. This caused a crash on long .dot strings because the final line in the first call to the stdout handler is typically cropped in the middle, causing a syntax error when that line is evaluated. The solution is to support multiple calls to the callback and append the data for all calls to a single variable, and only execute the command on the exit handler.